### PR TITLE
Expose missing preset modes

### DIFF
--- a/custom_components/nolongerevil/climate.py
+++ b/custom_components/nolongerevil/climate.py
@@ -70,6 +70,7 @@ class NLEClimate(NLEEntity, ClimateEntity):
         self._attr_supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.PRESET_MODE
             | ClimateEntityFeature.TURN_OFF
             | ClimateEntityFeature.TURN_ON
         )


### PR DESCRIPTION
The README says these are supported but the absence of `ClimateEntityFeature.PRESET_MODE` prevents that. Including them here ensures they work correctly.

Thanks for making a great plugin!