### PR TITLE
Stop logging users out on per-resource 403s and transient 401s

### DIFF
--- a/custom_components/nolongerevil/api.py
+++ b/custom_components/nolongerevil/api.py
@@ -213,7 +213,11 @@ class NLEApiClient:
                     raise NLEAuthenticationError("Invalid API key")
 
                 if response.status == 403:
-                    raise NLEAuthenticationError("Access denied to resource")
+                    # 403 is an authorization failure on a specific resource
+                    # (e.g. shared device without write permission, temperature
+                    # lock, transient gateway authz hiccup). The API key itself
+                    # is still valid, so this must not trigger a re-auth flow.
+                    raise NLEAPIError("Access denied to resource")
 
                 if response.status == 429:
                     retry_after = None

--- a/custom_components/nolongerevil/coordinator.py
+++ b/custom_components/nolongerevil/coordinator.py
@@ -72,10 +72,19 @@ class NLEDataUpdateCoordinator(DataUpdateCoordinator[dict[str, NLEDeviceStatus]]
                     status = await self.client.get_device_status(device_id)
                     self._apply_capability_latch(device_id, status)
                     data[device_id] = status
-                except NLEAuthenticationError:
-                    # Let auth errors bubble up so HA can trigger the re-auth
-                    # flow instead of silently logging and continuing.
-                    raise
+                except NLEAuthenticationError as err:
+                    # Probe with a list-devices call before tearing down the
+                    # integration: a single 401 on a per-device endpoint can
+                    # come from an upstream gateway blip rather than a revoked
+                    # key. Only escalate if the probe also fails.
+                    if not await self._api_key_still_valid():
+                        raise
+                    _LOGGER.debug(
+                        "Device %s returned auth error but API key probe "
+                        "succeeded; treating as transient: %s",
+                        device_id,
+                        err,
+                    )
                 except NLEError as err:
                     # Transient per-device errors (e.g. occasional HTTP 502 from
                     # the upstream gateway) — keep noise out of the log and let
@@ -98,6 +107,23 @@ class NLEDataUpdateCoordinator(DataUpdateCoordinator[dict[str, NLEDeviceStatus]]
             raise UpdateFailed("Failed to get status for any device")
 
         return data
+
+    async def _api_key_still_valid(self) -> bool:
+        """Probe the API to check whether the configured key is still valid.
+
+        Returns True if a list-devices call succeeds (key is good), False if
+        it fails with NLEAuthenticationError (key is revoked/invalid). Any
+        other failure is treated as "valid" since we can't distinguish it
+        from an upstream blip and shouldn't trigger re-auth on connectivity
+        errors.
+        """
+        try:
+            await self.client.get_devices()
+        except NLEAuthenticationError:
+            return False
+        except NLEError:
+            return True
+        return True
 
     def _apply_capability_latch(
         self, device_id: str, status: NLEDeviceStatus

--- a/custom_components/nolongerevil/manifest.json
+++ b/custom_components/nolongerevil/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/patricktr/NoLongerEvil-HomeAssistant/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "1.0.5"
+  "version": "1.0.6"
 }


### PR DESCRIPTION
## Summary

Yesterday's fix (#d74df63) routed any `NLEAuthenticationError` up to `ConfigEntryAuthFailed`, which logs the integration out. Two problems with that path caused users to be repeatedly kicked out even though their API key was still valid:

1. **`api.py` conflated 403 with 401.** Both HTTP 401 (`"Invalid API key"`) and HTTP 403 (`"Access denied to resource"`) were raised as `NLEAuthenticationError`. 403 is a resource-level authorization failure — the key is still valid — so a single shared-device 403, a temperature-lock 403, or a transient upstream-gateway authz blip was tearing down the whole integration. 403 now raises `NLEAPIError` instead.

2. **A single per-device 401 immediately escalated to re-auth.** A transient gateway 401 on one device's status call would log the user out. The coordinator now probes with a list-devices call before escalating; if the probe succeeds, the per-device 401 is treated as transient and logged at debug only. A real 401 (probe also fails) still surfaces the re-auth banner as intended.

Reported symptoms before fix: `Failed to set temperature: Access denied to resource` (a 403) followed by `Authentication failed while fetching nolongerevil data` and forced re-auth, twice in ~24h.

Bumps version to 1.0.6.

## Test plan

- [ ] Verify integration loads with a valid API key (no behavior change on happy path)
- [ ] Simulate a 403 from `set_temperature`: confirm climate.py logs the error but the integration is NOT logged out
- [ ] Simulate a 403 from `get_device_status`: confirm coordinator logs at debug and continues; no re-auth banner
- [ ] Simulate a 401 from `get_device_status` while `get_devices` still works: confirm transient handling, no re-auth
- [ ] Simulate a 401 from both `get_device_status` and `get_devices`: confirm `ConfigEntryAuthFailed` fires and re-auth banner appears
- [ ] Confirm manifest version reads 1.0.6

https://claude.ai/code/session_01CZsWbqHF6W9wpm7qqeKJdA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZsWbqHF6W9wpm7qqeKJdA)_