### PR TITLE
Document HA add-on Ingress port-exposure for self-hosted setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,23 @@ during setup and point the integration at your server's **Control API**:
 > between server versions. If you also run an MQTT broker, the server can publish
 > Home Assistant MQTT discovery records as an alternative to this integration.
 
+### Running the NLE server as a Home Assistant add-on
+
+If you're running the No Longer Evil server as a Home Assistant add-on, the
+add-on defaults to **Ingress** and only exposes its internal proxy ports — the
+Control API port (`8082`) is not reachable from this integration in that
+configuration. To use this integration with the add-on:
+
+1. Open the add-on **Configuration** tab
+2. Under **Network**, expose the **Control API + Web UI** port (`8082`) on the
+   host — assign it a host port (typically also `8082`)
+3. Restart the add-on
+4. In the integration setup, use your Home Assistant host's LAN IP with that
+   port, e.g. `http://<homeassistant-ip>:8082` (not the Ingress URL)
+
+See [#11](https://github.com/patricktr/NoLongerEvil-HomeAssistant/issues/11) for
+background on this configuration.
+
 ## Troubleshooting
 
 ### Authentication Errors


### PR DESCRIPTION
## Summary

v1.1.0's "Self-Hosted Users" section already covers the standard case (flashed server on the LAN at port 8082). The remaining gap, raised on #11 by @mattjacobson6: users running the NLE server as a Home Assistant add-on still hit setup failures because the add-on defaults to Ingress, which only exposes internal proxy ports — `8082` isn't reachable from this integration in that configuration.

Adds a short sub-section under "Self-Hosted Users" explaining:
- The Ingress default that's blocking the integration
- How to expose the **Control API + Web UI** port (`8082`) on the host via the add-on **Configuration → Network** tab
- That the integration should point at `http://<homeassistant-ip>:8082`, not the Ingress URL
- Links back to #11 for context

Quoted port label ("Control API + Web UI") matches @mattjacobson6's description verbatim. I couldn't independently verify the exact label in the NLE add-on UI — adjust the wording if it's drifted.

## Test plan

- [ ] Render the README on GitHub and verify the new sub-section formats correctly under "Self-Hosted Users"
- [ ] Confirm the port label ("Control API + Web UI") matches what's shown in the NLE add-on Configuration tab; reword if it's now different
- [ ] Verify the linked issue #11 renders as an auto-link

https://claude.ai/code/session_01CZsWbqHF6W9wpm7qqeKJdA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZsWbqHF6W9wpm7qqeKJdA)_